### PR TITLE
Fixes build error when devTools are disabled

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,7 +45,7 @@ export class AppComponent {
         createEpicMiddleware(combineEpics(...elephantsEpics.epics)),
         createEpicMiddleware(combineEpics(...lionsEpics.epics)),
       ],
-      devTools.isEnabled() ? [ devTools.enhancer() ] : null);
+      devTools.isEnabled() ? [ devTools.enhancer() ] : []);
     ngReduxRouter.initialize();
     provideReduxForms(ngRedux);
   }


### PR DESCRIPTION
Passing `null` as enhancer param breaks Redux's `compose()` method which expects an array.
Since devTools is usually disabled for production, any build would contain this error.