### PR TITLE
Updated API urls to https

### DIFF
--- a/src/app/animals/api/service.ts
+++ b/src/app/animals/api/service.ts
@@ -8,8 +8,8 @@ import { ANIMAL_TYPES, AnimalType, IAnimal, fromServer } from '../model';
 
 // A fake API on the internets.
 const URLS = {
-  [ANIMAL_TYPES.ELEPHANT]: 'http://www.mocky.io/v2/59200c34110000ce1a07b598',
-  [ANIMAL_TYPES.LION]: 'http://www.mocky.io/v2/5920141a25000023015998f2',
+  [ANIMAL_TYPES.ELEPHANT]: 'https://www.mocky.io/v2/59200c34110000ce1a07b598',
+  [ANIMAL_TYPES.LION]: 'https://www.mocky.io/v2/5920141a25000023015998f2',
 };
 
 @Injectable()


### PR DESCRIPTION
With API urls updated to https application can be launched on environments like stackblitz or github pages:
https://stackblitz.com/github/angular-redux/example-app
Otherwise it throws mixed content error:

```
Mixed Content: The page at 'https://qgnirlp.github.stackblitz.io/lions' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://www.mocky.io/v2/5920141a25000023015998f2'. This request has been blocked; the content must be served over HTTPS.
```